### PR TITLE
fix: add a trigger to manually run the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - '**'
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 #env:
 #  aaa: bbb


### PR DESCRIPTION
## WHAT
- `workflow_dispatch` をgithub actionsのtriggerに追加
<!--- 変更内容を記載 --->

## WHY
- PlantUML画像生成のCIを手動で実行するため
<!--- なぜこの変更が必要なのかを記載 --->
